### PR TITLE
Allow multiple extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const { importer } = require('sass-import-modules');
   importer(/* { options } */);
 ```
 
-- **ext** file extension, i.e `.scss`, `.sass`, `scss` or `sass` (default: `.scss`).
+- **extension** file extension, i.e `['.scss']`, `['.sass']`, `['scss']` or `['sass']` (default: `['.scss', '.css']`).
 - **resolvers** order of and set of resolvers to use (default: `['local', 'tilde', 'node']`):
   - `local`,
   - `tilde`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,11 @@
         "pruddy-error": "^2.0.2"
       }
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "nyc": "^15.1.0"
   },
   "dependencies": {
+    "async": "^3.2.0",
     "diagnostics": "^2.0.2",
     "resolve": "^1.17.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -65,19 +65,30 @@ function exists(file, done) {
 function node(base, file, extensions, next)  {
   debug('Resolving file from node_modules: %s', file);
 
+  //
+  // Remove .css if not explicit requested.
+  //
+  function check(error, result) {
+    if (result && path.extname(file) !== '.css') {
+      result = result.replace('.css', '');
+    }
+
+    next(error, result);
+  }
+
   return void resolve(file, {
     preserveSymlinks: false,
     basedir: base,
     extensions
   }, (error, result) => {
     if (result) {
-      return next(null, result);
+      return check(null, result);
     }
 
     resolve(file, {
       basedir: base,
       extensions
-    }, next);
+    }, check);
   });
 }
 

--- a/test/fixtures/index.scss
+++ b/test/fixtures/index.scss
@@ -1,4 +1,5 @@
 @import "./partial";
+@import "third";
 
 $height: 32px;
 

--- a/test/fixtures/node_modules/test/regular.css
+++ b/test/fixtures/node_modules/test/regular.css
@@ -1,0 +1,3 @@
+#line {
+  border: 0px;
+}

--- a/test/fixtures/third.css
+++ b/test/fixtures/third.css
@@ -1,0 +1,3 @@
+#regular {
+  height: 1px;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,7 @@ describe('SASS import modules', function () {
   });
 
   it('has configurable extensions', function (done) {
-    imports = importer({ ext: 'sass' }).bind({});
+    imports = importer({ extensions: ['sass'] }).bind({});
 
     imports('ext', fixtures, function ({ file } = {}) {
       assume(file).to.be.a('string');
@@ -35,7 +35,7 @@ describe('SASS import modules', function () {
     });
   });
 
-  it('imports relatives files', function (done) {
+  it.only('imports relatives files', function (done) {
     imports('second', fixtures, function ({ file } = {}) {
       assume(file).to.be.a('string');
       assume(file).to.include('test/fixtures/second.scss');

--- a/test/test.js
+++ b/test/test.js
@@ -63,7 +63,14 @@ describe('SASS import modules', function () {
     imports('test/file', fixtures, function ({ file } = {}) {
       assume(file).to.be.a('string');
       assume(file).to.include('test/fixtures/node_modules/test/file.scss');
-      done();
+
+      // .css should not be appended if explicitly added.
+      imports('test/regular', fixtures, function ({ file } = {}) {
+        assume(file).to.be.a('string');
+        assume(file).to.include('test/fixtures/node_modules/test/regular');
+        assume(file).to.not.include('.css');
+        done();
+      });
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,7 @@ describe('SASS import modules', function () {
     });
   });
 
-  it.only('imports relatives files', function (done) {
+  it('imports relatives files', function (done) {
     imports('second', fixtures, function ({ file } = {}) {
       assume(file).to.be.a('string');
       assume(file).to.include('test/fixtures/second.scss');

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,20 @@ describe('SASS import modules', function () {
     });
   });
 
+  it('resolves regular CSS imports', function (done) {
+    sass.render({
+      file: path.join(__dirname, 'fixtures', 'index.scss'),
+      importer: imports
+    }, (err, result) => {
+      const css = result.css.toString('utf-8');
+
+      assume(css).to.include('#regular {\n  height: 1px; ');
+      assume(css).to.include('height: 32px; }');
+
+      done();
+    });
+  });
+
   it('can resolve circular references', function (done) {
     sass.render({
       file: path.join(__dirname, 'fixtures', 'circular.scss'),


### PR DESCRIPTION
- Extend base functionality by allowing imports from multiple extensions
- Match the `node-sass` functionality that is very presumptuous about how to import a CSS file with or without extensions... 🤦 
- Add test to ensure CSS filenames without extension are returned as such and will result in imported content.
